### PR TITLE
Fix log message for clearing app counters

### DIFF
--- a/drasyl-p2p/src/peer/node_peer.rs
+++ b/drasyl-p2p/src/peer/node_peer.rs
@@ -269,7 +269,7 @@ impl NodePeer {
 
     /// Clear application traffic counters.
     pub(crate) fn clear_app_tx_rx(&self) {
-        trace!("Clear short ids");
+        trace!("Clear application counters");
         self.app_tx.store(0, SeqCst);
         self.app_rx.store(0, SeqCst);
     }


### PR DESCRIPTION
## Summary
- update NodePeer::clear_app_tx_rx() log message to reflect action

## Testing
- `cargo test -p drasyl`

------
https://chatgpt.com/codex/tasks/task_e_68894e2d0fb083269b4446235bc8b7bc