### PR TITLE
Allow unlimited peers when max_peers is 0

### DIFF
--- a/drasyl-p2p/src/node/inner.rs
+++ b/drasyl-p2p/src/node/inner.rs
@@ -46,7 +46,7 @@ impl NodeInner {
         udp_port: u16,
         cancellation_token: CancellationToken,
     ) -> Self {
-        assert!(opts.max_peers.is_power_of_two());
+        assert!(opts.max_peers == 0 || opts.max_peers.is_power_of_two());
 
         let peers = PeersList::new(peers, default_route);
 
@@ -120,7 +120,7 @@ impl NodeInner {
                     }
                     peer
                 } else {
-                    if peers.len() >= self.opts.max_peers as usize {
+                    if self.opts.max_peers != 0 && peers.len() >= self.opts.max_peers as usize {
                         return Err(Error::PeersListCapacityExceeded(self.opts.max_peers));
                     }
 

--- a/drasyl-p2p/src/node/send_handle.rs
+++ b/drasyl-p2p/src/node/send_handle.rs
@@ -156,7 +156,7 @@ impl SendHandle {
         let peer = if let Some(peer) = peers.get(&recipient) {
             peer
         } else {
-            if peers.len() >= inner.opts.max_peers as usize {
+            if inner.opts.max_peers != 0 && peers.len() >= inner.opts.max_peers as usize {
                 return Err(Error::PeersListCapacityExceeded(inner.opts.max_peers));
             }
 


### PR DESCRIPTION
## Summary
- allow `max_peers == 0` in Node
- ignore peer limit checks when the limit is zero

## Testing
- `cargo test --workspace --exclude drasyl-ui --locked --release`

------
https://chatgpt.com/codex/tasks/task_e_68894e2522a88326aab6cfd41d2d23f3