### PR TITLE
Add hex error tests

### DIFF
--- a/drasyl-p2p/src/util/hex.rs
+++ b/drasyl-p2p/src/util/hex.rs
@@ -92,4 +92,17 @@ mod tests {
             "ab7a1654d463f9986530bed00569cc895697827b802153b8ef1598579713045f"
         );
     }
+
+    #[test]
+    fn test_hex_to_bytes_invalid_length() {
+        assert!(matches!(hex_to_bytes::<2>("abc"), Err(HexError::InvalidLength)));
+    }
+
+    #[test]
+    fn test_hex_to_bytes_invalid_character() {
+        assert!(matches!(
+            hex_to_bytes::<1>("g1"),
+            Err(HexError::InvalidCharacter(b'g'))
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
- extend `hex_to_bytes` tests with invalid length and character cases

## Testing
- `cargo test -p drasyl --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68894e337b9c832693b76460e9e7d463