### PR TITLE
Replaced libsodium with dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "bytes",
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -639,12 +639,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.11.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a229bfd78e4827c91b9b95784f69492c1b77c1ab75a45a8a037b139215086f94"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -959,7 +980,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -1075,6 +1096,18 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cordyceps"
@@ -1270,6 +1303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a23fa214dea9efd4dacee5a5614646b30216ae0f05d4bb51bafb50e9da1c5be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "crypto_box"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,7 +1358,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rand_core 0.6.4",
  "rustc_version",
@@ -1389,7 +1431,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "pem-rfc7468",
  "zeroize",
@@ -1504,9 +1546,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460dd7f37e4950526b54a5a6b1f41b6c8e763c58eb9a8fc8fc05ba5c2f44ca7b"
+dependencies = [
+ "block-buffer 0.11.0-rc.4",
+ "const-oid 0.10.1",
+ "crypto-common 0.2.0-rc.3",
+ "zeroize",
 ]
 
 [[package]]
@@ -1662,9 +1716,11 @@ dependencies = [
  "aegis",
  "ahash",
  "arc-swap",
+ "blake2b_simd",
  "bytes",
  "criterion",
  "derive_builder",
+ "ed25519-dalek",
  "futures",
  "if-addrs",
  "lazy_static",
@@ -1674,13 +1730,16 @@ dependencies = [
  "prometheus",
  "rand_chacha 0.9.0",
  "serde",
+ "sha2 0.11.0-rc.0",
  "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "x25519-dalek",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -1765,15 +1824,15 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2863,7 +2922,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2959,6 +3018,15 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "hybrid-array"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -5006,7 +5074,7 @@ checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6280,7 +6348,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6291,7 +6359,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1d2e6b3cc4e43a8258a9a3b17aa5dfd2cc5186c7024bba8a64aa65b2c71a59"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-rc.0",
 ]
 
 [[package]]
@@ -7287,7 +7366,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -8466,6 +8545,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8617,6 +8708,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "zerovec"

--- a/drasyl-p2p/Cargo.toml
+++ b/drasyl-p2p/Cargo.toml
@@ -16,7 +16,6 @@ lazy_static = { workspace = true }
 arc-swap = { workspace = true }
 futures = { workspace = true }
 if-addrs = "0.14.0"
-libsodium-sys-stable = { version = "1.22.2", features = ["minimal"] }
 aegis = "0.9.0"
 rand_chacha = { version = "0.9.0", features = ["os_rng"] }
 zerocopy = { version = "0.8.26", features = ["derive"] }
@@ -24,10 +23,20 @@ lz4_flex = { version = "0.11" }
 socket2 = { version = "0.6.0", features = ["all"] }
 bytes = "1.10.1"
 prometheus = { workspace = true, optional = true, features = ["push"] }
+ed25519-dalek = { version = "2.2.0", features = ["rand_core", "zeroize"] }
+x25519-dalek = { version = "2.0.1", features = ["static_secrets", "zeroize"] }
+blake2b_simd = "1.0.3"
+sha2 = { version = "0.11.0-rc.0", features = ["zeroize"] }
+zeroize = "1.8.1"
 
 [dev-dependencies]
 criterion = { version = "0.7", features = ["async_tokio", "html_reports"] }
 tracing-subscriber  = { workspace = true }
+libsodium-sys-stable = { version = "1.22.2", features = ["minimal"] }
+
+[[bench]]
+name = "crypto"
+harness = false
 
 [[bench]]
 name = "sha256"

--- a/drasyl-p2p/benches/crypto.rs
+++ b/drasyl-p2p/benches/crypto.rs
@@ -1,0 +1,143 @@
+// benches/curve25519.rs
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use drasyl_p2p::crypto::{
+    compute_kx_session_keys,
+    convert_ed25519_pk_to_curve25519_pk,
+    convert_ed25519_sk_to_curve25519_sk,
+    generate_sign_keypair,
+    AgreementPubKey, AgreementSecKey, SigningPubKey, SigningSecKey, SessionKey,
+};
+use libsodium_sys as sodium;
+
+fn sodium_init_once() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| unsafe { let _ = sodium::sodium_init(); });
+}
+
+// --- Helpers: neue Impl ausschließlich über crypto/mod.rs -------------------
+fn gen_x25519_pair_new() -> (AgreementPubKey, AgreementSecKey) {
+    let (ed_pk, ed_sk): (SigningPubKey, SigningSecKey) = generate_sign_keypair().unwrap();
+    let pk = convert_ed25519_pk_to_curve25519_pk(&ed_pk).unwrap();
+    let sk = convert_ed25519_sk_to_curve25519_sk(&ed_sk).unwrap();
+    (pk, sk)
+}
+
+// --- Benchmarks ------------------------------------------------------------
+
+fn bench_kx_session_keys(c: &mut Criterion) {
+    sodium_init_once();
+
+    // Feste Test-Schlüssel (einmal erzeugen, in beiden Varianten verwenden)
+    let (my_pk, my_sk) = gen_x25519_pair_new();
+    let (peer_pk, _peer_sk) = gen_x25519_pair_new();
+
+    let mut group = c.benchmark_group("KX-session-keys");
+
+    // libsodium: crypto_kx_{client,server}_session_keys
+    group.bench_function("libsodium/kx", |b| {
+        let mut rx = [0u8; 32];
+        let mut tx = [0u8; 32];
+        b.iter(|| {
+            let rc = if my_pk < peer_pk {
+                unsafe {
+                    sodium::crypto_kx_client_session_keys(
+                        rx.as_mut_ptr(),
+                        tx.as_mut_ptr(),
+                        black_box(my_pk.as_ptr()),
+                        black_box(my_sk.as_ptr()),
+                        black_box(peer_pk.as_ptr()),
+                    )
+                }
+            } else {
+                unsafe {
+                    sodium::crypto_kx_server_session_keys(
+                        rx.as_mut_ptr(),
+                        tx.as_mut_ptr(),
+                        black_box(my_pk.as_ptr()),
+                        black_box(my_sk.as_ptr()),
+                        black_box(peer_pk.as_ptr()),
+                    )
+                }
+            };
+            assert_eq!(rc, 0);
+            black_box((&rx, &tx));
+        });
+    });
+
+    // neue Impl: compute_kx_session_keys aus crypto/mod.rs
+    group.bench_function("new-impl/kx", |b| {
+        b.iter(|| {
+            let (rx, tx): (SessionKey, SessionKey) = compute_kx_session_keys(
+                black_box(&my_pk),
+                black_box(&my_sk),
+                black_box(&peer_pk),
+            ).unwrap();
+            black_box((rx, tx));
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_ed25519_to_x25519(c: &mut Criterion) {
+    sodium_init_once();
+
+    // fixes Ed25519-Paar (einmal)
+    let (ed_pk, ed_sk): (SigningPubKey, SigningSecKey) = generate_sign_keypair().unwrap();
+
+    let mut group = c.benchmark_group("Ed25519->X25519");
+
+    // Public-Key-Konvertierung
+    group.bench_function("libsodium/pk_to_curve25519", |b| {
+        let mut out = [0u8; 32];
+        b.iter(|| {
+            let rc = unsafe {
+                sodium::crypto_sign_ed25519_pk_to_curve25519(
+                    out.as_mut_ptr(),
+                    black_box(ed_pk.as_ptr()),
+                )
+            };
+            assert_eq!(rc, 0);
+            black_box(out);
+        });
+    });
+
+    group.bench_function("new-impl/pk_to_curve25519", |b| {
+        b.iter(|| {
+            let out = convert_ed25519_pk_to_curve25519_pk(black_box(&ed_pk)).unwrap();
+            black_box(out);
+        });
+    });
+
+    // Secret-Key-Konvertierung
+    group.bench_function("libsodium/sk_to_curve25519", |b| {
+        let mut out = [0u8; 32];
+        b.iter(|| {
+            let rc = unsafe {
+                sodium::crypto_sign_ed25519_sk_to_curve25519(
+                    out.as_mut_ptr(),
+                    black_box(ed_sk.as_ptr()),
+                )
+            };
+            assert_eq!(rc, 0);
+            black_box(out);
+        });
+    });
+
+    group.bench_function("new-impl/sk_to_curve25519", |b| {
+        b.iter(|| {
+            let out = convert_ed25519_sk_to_curve25519_sk(black_box(&ed_sk)).unwrap();
+            black_box(out);
+        });
+    });
+
+    group.finish();
+}
+
+fn curve_benches(c: &mut Criterion) {
+    bench_kx_session_keys(c);
+    bench_ed25519_to_x25519(c);
+}
+
+criterion_group!(benches, curve_benches);
+criterion_main!(benches);

--- a/drasyl-p2p/benches/sha256.rs
+++ b/drasyl-p2p/benches/sha256.rs
@@ -8,7 +8,7 @@ fn sha256_libsodium(input: &[u8]) -> Result<[u8; 32], Error> {
         sodium::crypto_hash_sha256(hash.as_mut_ptr(), input.as_ptr(), input.len() as u64)
     };
     if result != 0 {
-        return Err(Error::LibsodiumError);
+        return Err(Error::DalekError);
     }
 
     Ok(hash)
@@ -19,10 +19,12 @@ fn sha256_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("SHA256");
 
-    group.bench_function("ring", |b| b.iter(|| sha256(black_box(test_data)).unwrap()));
-
     group.bench_function("libsodium", |b| {
         b.iter(|| sha256_libsodium(black_box(test_data)).unwrap());
+    });
+
+    group.bench_function("dalek/sha2", |b| {
+        b.iter(|| sha256(black_box(test_data)).unwrap());
     });
 
     group.finish();

--- a/drasyl-p2p/src/crypto/error.rs
+++ b/drasyl-p2p/src/crypto/error.rs
@@ -6,8 +6,8 @@ pub enum Error {
     #[error("Generated session keys are identical")]
     SessionKeysIdentical,
 
-    #[error("A Libsodium cryptographic error occurred")]
-    LibsodiumError,
+    #[error("A dalek cryptographic error occurred")]
+    DalekError,
 
     #[error("An AEGIS cryptographic error occurred")]
     DecryptFailed,

--- a/drasyl-p2p/src/crypto/mod.rs
+++ b/drasyl-p2p/src/crypto/mod.rs
@@ -2,25 +2,34 @@ mod error;
 mod session_key;
 
 pub use error::*;
-use libsodium_sys as sodium;
-use rand_chacha::ChaCha20Rng;
 use rand_chacha::rand_core::{RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
 pub use session_key::SessionKey;
 use std::cell::RefCell;
 
+use blake2b_simd::Params;
+
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use sha2::{Digest, Sha256, Sha512};
+use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret as X25519StaticSecret};
+use zeroize::Zeroize;
+
 pub(crate) const SHA256_BYTES: usize = 32;
+pub(crate) const SHA512_BYTES: usize = 64;
 pub(crate) const ED25519_SECRETKEYBYTES: usize = 64;
 pub(crate) const ED25519_PUBLICKEYBYTES: usize = 32;
+pub(crate) const ED25519_SEEDBYTES: usize = 32;
 pub(crate) const CURVE25519_SECRETKEYBYTES: usize = 32;
 pub(crate) const CURVE25519_PUBLICKEYBYTES: usize = 32;
 pub(crate) const AEGIS_KEYBYTES: usize = 32;
 pub(crate) const AEGIS_NBYTES: usize = 32;
 pub(crate) const AEGIS_ABYTES: usize = 16;
+pub(crate) const BLAKE2B512_LENGTH: usize = 64;
 
 pub(crate) type Nonce = [u8; AEGIS_NBYTES];
 pub(crate) type AuthTag = [u8; AEGIS_ABYTES];
-pub(crate) type SigningSecKey = [u8; ED25519_SECRETKEYBYTES];
-pub(crate) type SigningPubKey = [u8; ED25519_PUBLICKEYBYTES];
+pub type SigningSecKey = [u8; ED25519_SECRETKEYBYTES];
+pub type SigningPubKey = [u8; ED25519_PUBLICKEYBYTES];
 pub type AgreementSecKey = [u8; CURVE25519_SECRETKEYBYTES];
 pub type AgreementPubKey = [u8; CURVE25519_PUBLICKEYBYTES];
 
@@ -33,100 +42,117 @@ pub fn random_bytes(buf: &mut [u8]) {
     });
 }
 
-pub(crate) fn generate_sign_keypair() -> Result<(SigningPubKey, SigningSecKey), Error> {
-    let mut pk_key = [0u8; ED25519_PUBLICKEYBYTES];
-    let mut sk_key = [0u8; ED25519_SECRETKEYBYTES];
+pub fn generate_sign_keypair() -> Result<(SigningPubKey, SigningSecKey), Error> {
+    let seed: [u8; ED25519_SEEDBYTES] = RNG.with(|rng| {
+        let mut rng = rng.borrow_mut();
+        let mut s = [0u8; ED25519_SEEDBYTES];
+        rng.fill_bytes(&mut s);
+        s
+    });
 
-    let result = unsafe { sodium::crypto_sign_keypair(pk_key.as_mut_ptr(), sk_key.as_mut_ptr()) };
+    let signing = SigningKey::from_bytes(&seed);
+    let verifying: VerifyingKey = signing.verifying_key();
+    let pk_bytes: SigningPubKey = verifying.to_bytes();
 
-    if result != 0 {
-        return Err(Error::LibsodiumError);
-    }
+    // Backwards compatibility with libsodium: seed || pk
+    let mut sk_bytes: SigningSecKey = [0u8; ED25519_SECRETKEYBYTES];
+    sk_bytes[..ED25519_SEEDBYTES].copy_from_slice(&seed);
+    sk_bytes[ED25519_SEEDBYTES..].copy_from_slice(&pk_bytes);
 
-    Ok((pk_key, sk_key))
+    Ok((pk_bytes, sk_bytes))
 }
 
+// ========= libsodium compatible key exchange: rx||tx = BLAKE2b-512(p.n || client_pk || server_pk) =========
 pub fn compute_kx_session_keys(
     my_pk: &AgreementPubKey,
     my_sk: &AgreementSecKey,
     peer_pk: &AgreementPubKey,
 ) -> Result<(SessionKey, SessionKey), Error> {
-    let mut rx_key = [0u8; AEGIS_KEYBYTES];
-    let mut tx_key = [0u8; AEGIS_KEYBYTES];
+    use core::cmp::Ordering;
 
-    match match my_pk.cmp(peer_pk) {
-        std::cmp::Ordering::Less => -1,
-        std::cmp::Ordering::Greater => 1,
-        std::cmp::Ordering::Equal => 0,
-    } {
-        -1 => {
-            let result = unsafe {
-                sodium::crypto_kx_client_session_keys(
-                    rx_key.as_mut_ptr(),
-                    tx_key.as_mut_ptr(),
-                    my_pk.as_ptr(),
-                    my_sk.as_ptr(),
-                    peer_pk.as_ptr(),
-                )
-            };
-            if result != 0 {
-                return Err(Error::LibsodiumError);
-            }
-
-            Ok((rx_key.into(), tx_key.into()))
-        }
-        1 => {
-            let result = unsafe {
-                sodium::crypto_kx_server_session_keys(
-                    rx_key.as_mut_ptr(),
-                    tx_key.as_mut_ptr(),
-                    my_pk.as_ptr(),
-                    my_sk.as_ptr(),
-                    peer_pk.as_ptr(),
-                )
-            };
-            if result != 0 {
-                return Err(Error::LibsodiumError);
-            }
-
-            Ok((rx_key.into(), tx_key.into()))
-        }
-        _ => Err(Error::SessionKeysIdentical),
+    if my_pk == peer_pk {
+        return Err(Error::SessionKeysIdentical);
     }
+
+    let (client_pk, server_pk, i_am_client) = match my_pk.cmp(peer_pk) {
+        Ordering::Less => (*my_pk, *peer_pk, true),
+        Ordering::Greater => (*peer_pk, *my_pk, false),
+        Ordering::Equal => unreachable!(),
+    };
+
+    // X25519: Shared Secret
+    let my_secret = X25519StaticSecret::from(*my_sk); // clamped
+    let their_public = X25519PublicKey::from(*peer_pk);
+    let shared = my_secret.diffie_hellman(&their_public);
+
+    // optional: "contributory" check
+    if !shared.was_contributory() {
+        return Err(Error::DalekError);
+    }
+
+    // BLAKE2b-512 like libsodium (p.n || client_pk || server_pk)
+    let hash = Params::new()
+        .hash_length(BLAKE2B512_LENGTH)
+        .to_state()
+        .update(shared.as_bytes())
+        .update(&client_pk)
+        .update(&server_pk)
+        .finalize();
+    let digest = hash.as_bytes();
+
+    let mut rx = [0u8; AEGIS_KEYBYTES];
+    let mut tx = [0u8; AEGIS_KEYBYTES];
+    rx.copy_from_slice(&digest[..AEGIS_KEYBYTES]); // 32 bytes
+    tx.copy_from_slice(&digest[AEGIS_KEYBYTES..]); // 32 bytes
+
+    // libsodium format: returned keys are relative to the "my_*" keys
+    let (rx_key, tx_key) = if i_am_client {
+        (rx, tx)
+    } else {
+        // server uses the keys in the reverse order
+        (tx, rx)
+    };
+
+    Ok((rx_key.into(), tx_key.into()))
 }
 
 pub fn convert_ed25519_pk_to_curve25519_pk(pk: &SigningPubKey) -> Result<AgreementPubKey, Error> {
-    let mut agreement_key = [0u8; CURVE25519_PUBLICKEYBYTES];
-    let result = unsafe {
-        sodium::crypto_sign_ed25519_pk_to_curve25519(agreement_key.as_mut_ptr(), pk.as_ptr())
-    };
-    if result != 0 {
-        return Err(Error::LibsodiumError);
-    }
+    let vk = VerifyingKey::from_bytes(pk).map_err(|_| Error::DalekError)?;
+    let mont = vk.to_montgomery(); // Montgomery coordinate (X25519 Public)
 
-    Ok(agreement_key)
+    Ok(mont.to_bytes())
 }
 
 pub fn convert_ed25519_sk_to_curve25519_sk(sk: &SigningSecKey) -> Result<AgreementSecKey, Error> {
-    let mut agreement_key = [0u8; CURVE25519_SECRETKEYBYTES];
-    let result = unsafe {
-        sodium::crypto_sign_ed25519_sk_to_curve25519(agreement_key.as_mut_ptr(), sk.as_ptr())
-    };
-    if result != 0 {
-        return Err(Error::LibsodiumError);
-    }
+    // see also: https://github.com/jedisct1/libsodium/blob/85ddc5c2c6c7b8f7c99f9af6039e18f1f2ca0daa/src/libsodium/crypto_sign/ed25519/ref10/keypair.c#L71
+    let seed: [u8; CURVE25519_SECRETKEYBYTES] = sk[..CURVE25519_SECRETKEYBYTES]
+        .try_into()
+        .map_err(|_| Error::DalekError)?;
 
-    Ok(agreement_key)
+    // 1) SHA-512(seed)
+    let mut h: [u8; SHA512_BYTES] = Sha512::digest(&seed).into();
+
+    // 2) X25519 clamping
+    h[0] &= 248;
+    h[31] &= 127;
+    h[31] |= 64;
+
+    // 3) return first 32 Bytes
+    let mut out: AgreementSecKey = [0u8; CURVE25519_SECRETKEYBYTES];
+    out.copy_from_slice(&h[..CURVE25519_SECRETKEYBYTES]);
+
+    h.zeroize();
+
+    Ok(out)
 }
 
 pub fn sha256(input: &[u8]) -> Result<[u8; SHA256_BYTES], Error> {
     let mut hash = [0u8; SHA256_BYTES];
-    let result = unsafe {
-        sodium::crypto_hash_sha256(hash.as_mut_ptr(), input.as_ptr(), input.len() as u64)
-    };
-    if result != 0 {
-        return Err(Error::LibsodiumError);
-    }
+    let mut hasher = Sha256::new();
+    hasher.update(input);
+
+    let out = hasher.finalize();
+    hash.copy_from_slice(&out);
 
     Ok(hash)
 }
@@ -150,6 +176,26 @@ mod tests {
                     sk.iter().any(|&b| b != 0),
                     "Secret key consists only of zeros!"
                 );
+
+                match convert_ed25519_pk_to_curve25519_pk(&pk) {
+                    Ok(converted_pk) => {
+                        assert!(
+                            converted_pk.iter().any(|&b| b != 0),
+                            "Converted public key consists only of zeros!"
+                        )
+                    }
+                    Err(_) => panic!("Converted public key generation error"),
+                }
+
+                match convert_ed25519_sk_to_curve25519_sk(&sk) {
+                    Ok(converted_sk) => {
+                        assert!(
+                            converted_sk.iter().any(|&b| b != 0),
+                            "Converted secret key consists only of zeros!"
+                        )
+                    }
+                    Err(_) => panic!("Converted secret key generation error"),
+                }
             }
             Err(_) => panic!("Long Time Key Generation Error"),
         }
@@ -161,8 +207,10 @@ mod tests {
         let hash = sha256(input).unwrap();
         assert_eq!(
             hash,
-            hex_to_bytes::<32>("dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f")
-                .unwrap()
+            hex_to_bytes::<SHA256_BYTES>(
+                "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f"
+            )
+            .unwrap()
         );
     }
 }

--- a/drasyl-p2p/src/crypto/session_key.rs
+++ b/drasyl-p2p/src/crypto/session_key.rs
@@ -11,7 +11,7 @@ pub struct SessionKey([u8; AEGIS_KEYBYTES]);
 
 impl SessionKey {
     /// Get the raw bytes of the session key.
-    pub(crate) fn as_bytes(&self) -> &[u8; AEGIS_KEYBYTES] {
+    pub fn as_bytes(&self) -> &[u8; AEGIS_KEYBYTES] {
         &self.0
     }
 }

--- a/drasyl-p2p/tests/crypto.rs
+++ b/drasyl-p2p/tests/crypto.rs
@@ -1,0 +1,201 @@
+use drasyl_p2p::crypto as new;
+use drasyl_p2p::crypto::{Error, SessionKey, SigningPubKey, SigningSecKey};
+use libsodium_sys as sodium;
+use std::sync::Once;
+
+fn sodium_init_once() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| unsafe { assert!(sodium::sodium_init() >= 0) });
+}
+
+// ---------------------------------------------------------------------------
+// Old (libsodium) references
+// ---------------------------------------------------------------------------
+mod old_ref {
+    use super::*;
+    
+    pub(crate) const ED25519_SECRETKEYBYTES: usize = 64;
+    pub(crate) const ED25519_PUBLICKEYBYTES: usize = 32;
+    pub(crate) const CURVE25519_SECRETKEYBYTES: usize = 32;
+    pub(crate) const CURVE25519_PUBLICKEYBYTES: usize = 32;
+
+    pub(crate) type SigningSecKey = [u8; ED25519_SECRETKEYBYTES];
+    pub(crate) type SigningPubKey = [u8; ED25519_PUBLICKEYBYTES];
+    pub(crate) type AgreementSecKey = [u8; CURVE25519_SECRETKEYBYTES];
+    pub(crate) type AgreementPubKey = [u8; CURVE25519_PUBLICKEYBYTES];
+
+    pub(crate) const AEGIS_KEYBYTES: usize = 32;
+
+    pub fn generate_sign_keypair() -> Result<(SigningPubKey, SigningSecKey), Error> {
+        let mut pk_key = [0u8; ED25519_PUBLICKEYBYTES];
+        let mut sk_key = [0u8; ED25519_SECRETKEYBYTES];
+
+        let result =
+            unsafe { sodium::crypto_sign_keypair(pk_key.as_mut_ptr(), sk_key.as_mut_ptr()) };
+
+        if result != 0 {
+            return Err(Error::DalekError);
+        }
+
+        Ok((pk_key, sk_key))
+    }
+
+    pub fn compute_kx_session_keys(
+        my_pk: &AgreementPubKey,
+        my_sk: &AgreementSecKey,
+        peer_pk: &AgreementPubKey,
+    ) -> Result<(SessionKey, SessionKey), Error> {
+        let mut rx_key = [0u8; AEGIS_KEYBYTES];
+        let mut tx_key = [0u8; AEGIS_KEYBYTES];
+
+        match match my_pk.cmp(peer_pk) {
+            std::cmp::Ordering::Less => -1,
+            std::cmp::Ordering::Greater => 1,
+            std::cmp::Ordering::Equal => 0,
+        } {
+            -1 => {
+                let result = unsafe {
+                    sodium::crypto_kx_client_session_keys(
+                        rx_key.as_mut_ptr(),
+                        tx_key.as_mut_ptr(),
+                        my_pk.as_ptr(),
+                        my_sk.as_ptr(),
+                        peer_pk.as_ptr(),
+                    )
+                };
+                if result != 0 {
+                    return Err(Error::DalekError);
+                }
+
+                Ok((rx_key.into(), tx_key.into()))
+            }
+            1 => {
+                let result = unsafe {
+                    sodium::crypto_kx_server_session_keys(
+                        rx_key.as_mut_ptr(),
+                        tx_key.as_mut_ptr(),
+                        my_pk.as_ptr(),
+                        my_sk.as_ptr(),
+                        peer_pk.as_ptr(),
+                    )
+                };
+                if result != 0 {
+                    return Err(Error::DalekError);
+                }
+
+                Ok((rx_key.into(), tx_key.into()))
+            }
+            _ => Err(Error::SessionKeysIdentical),
+        }
+    }
+
+    pub fn convert_ed25519_pk_to_curve25519_pk(
+        pk: &SigningPubKey,
+    ) -> Result<AgreementPubKey, Error> {
+        let mut agreement_key = [0u8; CURVE25519_PUBLICKEYBYTES];
+        let result = unsafe {
+            sodium::crypto_sign_ed25519_pk_to_curve25519(agreement_key.as_mut_ptr(), pk.as_ptr())
+        };
+        if result != 0 {
+            return Err(Error::DalekError);
+        }
+
+        Ok(agreement_key)
+    }
+
+    pub fn convert_ed25519_sk_to_curve25519_sk(
+        sk: &SigningSecKey,
+    ) -> Result<AgreementSecKey, Error> {
+        let mut agreement_key = [0u8; CURVE25519_SECRETKEYBYTES];
+        let result = unsafe {
+            sodium::crypto_sign_ed25519_sk_to_curve25519(agreement_key.as_mut_ptr(), sk.as_ptr())
+        };
+        if result != 0 {
+            return Err(Error::DalekError);
+        }
+
+        Ok(agreement_key)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: neue Implementierung muss exakt mit der alten übereinstimmen
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ed25519_pk_conversion_matches_old_ref_many() {
+    sodium_init_once();
+    for _ in 0..64 {
+        let (ed_pk, _ed_sk): (SigningPubKey, SigningSecKey) =
+            old_ref::generate_sign_keypair().unwrap();
+        let ours = new::convert_ed25519_pk_to_curve25519_pk(&ed_pk).unwrap();
+        let theirs = old_ref::convert_ed25519_pk_to_curve25519_pk(&ed_pk).unwrap();
+        assert_eq!(ours, theirs, "pk_to_curve25519 mismatch");
+    }
+}
+
+#[test]
+fn ed25519_sk_conversion_matches_old_ref_many() {
+    sodium_init_once();
+    for _ in 0..64 {
+        let (_ed_pk, ed_sk): (SigningPubKey, SigningSecKey) =
+            old_ref::generate_sign_keypair().unwrap();
+        let ours = new::convert_ed25519_sk_to_curve25519_sk(&ed_sk).unwrap();
+        let theirs = old_ref::convert_ed25519_sk_to_curve25519_sk(&ed_sk).unwrap();
+        assert_eq!(ours, theirs, "sk_to_curve25519 mismatch");
+    }
+}
+
+#[test]
+fn kx_session_keys_match_old_ref_both_roles_many() {
+    sodium_init_once();
+
+    for _ in 0..32 {
+        // X25519 Keypairs über die alte Referenz erzeugen (libsodium), damit beide Welten identische Inputs sehen
+        let (my_pk_0, my_sk_0): (SigningPubKey, SigningSecKey) =
+            old_ref::generate_sign_keypair().unwrap();
+        let (peer_pk_0, peer_sk_0): (SigningPubKey, SigningSecKey) =
+            old_ref::generate_sign_keypair().unwrap();
+        let mut my_pk = old_ref::convert_ed25519_pk_to_curve25519_pk(&my_pk_0).unwrap();
+        let mut my_sk = old_ref::convert_ed25519_sk_to_curve25519_sk(&my_sk_0).unwrap();
+        let mut peer_pk = old_ref::convert_ed25519_pk_to_curve25519_pk(&peer_pk_0).unwrap();
+        let mut peer_sk = old_ref::convert_ed25519_sk_to_curve25519_sk(&peer_sk_0).unwrap();
+        let rc1 = unsafe { sodium::crypto_kx_keypair(my_pk.as_mut_ptr(), my_sk.as_mut_ptr()) };
+        let rc2 = unsafe { sodium::crypto_kx_keypair(peer_pk.as_mut_ptr(), peer_sk.as_mut_ptr()) };
+        assert_eq!(rc1, 0);
+        assert_eq!(rc2, 0);
+
+        // alte Referenz (aus Sicht "my_*")
+        let (rx_old, tx_old) = old_ref::compute_kx_session_keys(&my_pk, &my_sk, &peer_pk).unwrap();
+        // neue Impl (aus Sicht "my_*")
+        let (rx_new, tx_new): (SessionKey, SessionKey) =
+            new::compute_kx_session_keys(&my_pk, &my_sk, &peer_pk).unwrap();
+
+        assert_eq!(
+            rx_new.as_bytes(),
+            rx_old.as_bytes(),
+            "rx mismatch (my view)"
+        );
+        assert_eq!(
+            tx_new.as_bytes(),
+            tx_old.as_bytes(),
+            "tx mismatch (my view)"
+        );
+
+        // Peer-Perspektive
+        let (rx_old_p, tx_old_p) =
+            old_ref::compute_kx_session_keys(&peer_pk, &peer_sk, &my_pk).unwrap();
+        let (rx_new_p, tx_new_p): (SessionKey, SessionKey) =
+            new::compute_kx_session_keys(&peer_pk, &peer_sk, &my_pk).unwrap();
+        assert_eq!(
+            rx_new_p.as_bytes(),
+            rx_old_p.as_bytes(),
+            "rx mismatch (peer view)"
+        );
+        assert_eq!(
+            tx_new_p.as_bytes(),
+            tx_old_p.as_bytes(),
+            "tx mismatch (peer view)"
+        );
+    }
+}


### PR DESCRIPTION
## Replace libsodium with ed25519- and x25519-dalek

### What changed
- **Removed `libsodium-sys-stable`** dependency in production code  
- Replaced with native Rust crates:
  - [`ed25519-dalek`](https://crates.io/crates/ed25519-dalek) and [`x25519-dalek`](https://crates.io/crates/x25519-dalek) for key generation, conversion, and Diffie–Hellman key exchange  
  - [`blake2b-simd`](https://crates.io/crates/blake2b-simd) and [`sha2`](https://crates.io/crates/sha2) for hashing/KDF  
  - [`zeroize`](https://crates.io/crates/zeroize) for secure memory clearing  

- **Error handling**: replaced `LibsodiumError` with `DalekError`

- **Benchmarks** added/updated:
  - `benches/crypto.rs`: compares libsodium vs. new dalek implementations for:
    - KX session keys
    - Ed25519→X25519 conversions
  - `benches/sha256.rs`: compares SHA-256 (libsodium vs. new implementation)

- **Cargo.toml changes**:
  - `libsodium-sys` only as `dev-dependency` (for compatibility tests/benches)

---

### Motivation
- Native Rust crypto removes FFI overhead and simplifies cross-platform builds (incl. iOS/tvOS)  
- Benchmarks ensure parity with libsodium’s behavior and acceptable performance (with asm features enabled)

---

### Benchmarks

### Benchmarks

| Benchmark                | libsodium (ns/iter)        | dalek (ns/iter)          |
|--------------------------|---------------------------:|-------------------------:|
| KX session keys          | 28 939 – 30 771 µs         | 35 058 – 36 177 µs       |
| Ed25519→X25519 (pk)      | 30 499 – 30 622 µs         | 5 796 – 5 839 µs         |
| Ed25519→X25519 (sk)      | 259 – 260 ns               | 116 – 117 ns             |
| SHA-256                  | 380 – 383 ns               | 48.7 – 49.3 ns           |


![kx](https://github.com/user-attachments/assets/b28c6da9-f264-4172-a8cf-865b92565af4)


![conversion](https://github.com/user-attachments/assets/ada9ac4c-0400-4fb6-bf8b-56370ac8f646)

![sha](https://github.com/user-attachments/assets/9d7178d4-ac30-4745-8eef-58439fd440dc)
